### PR TITLE
Updated k8s resources apiversion to latest supported k8s 1.17 version

### DIFF
--- a/helm/cicdhub/Chart.yaml
+++ b/helm/cicdhub/Chart.yaml
@@ -1,10 +1,5 @@
-name: cicdhub
-version: 2.0.6
 apiVersion: v1
 description: Deployment of LM CICDHub
-maintainers:
-- name: Accanto Systems
-  email: containers@accantosystems.com
 icon: http://www.accantosystems.com/wp-content/uploads/2017/06/Accanto-w_white-systems200px.png
 keywords:
 - Stratoss
@@ -14,4 +9,8 @@ keywords:
 - Accanto
 - CICDHub
 - CICD Hub
-engine: gotpl
+maintainers:
+- email: containers@accantosystems.com
+  name: Accanto Systems
+name: cicdhub
+version: 2.0.6

--- a/helm/cicdhub/requirements.lock
+++ b/helm/cicdhub/requirements.lock
@@ -1,0 +1,21 @@
+dependencies:
+- name: sonatype-nexus
+  repository: https://kubernetes-charts.storage.googleapis.com
+  version: 1.16.0
+- name: jenkins
+  repository: https://kubernetes-charts.storage.googleapis.com
+  version: 1.3.2
+- name: docker-registry
+  repository: https://kubernetes-charts.storage.googleapis.com
+  version: 1.7.0
+- name: gogs
+  repository: https://kubernetes-charts-incubator.storage.googleapis.com/
+  version: 0.7.6
+- name: nginx-ingress
+  repository: https://kubernetes-charts.storage.googleapis.com
+  version: 0.29.2
+- name: openldap
+  repository: https://kubernetes-charts.storage.googleapis.com
+  version: 0.2.3
+digest: sha256:111d166dd597c97b105d3a3ba5f75b44f8fa72e12edff3a692faaff9d71482fe
+generated: 2019-10-30T15:00:52.097453633Z

--- a/helm/cicdhub/values.yaml
+++ b/helm/cicdhub/values.yaml
@@ -27,7 +27,7 @@ nexus:
     enabled: true
     ## Customise the storage class. Leave undefined to use the default on the kubernetes cluster
     ## Use storageClass: nexus-storage if using local volumes created by volumesInit
-    #storageClass: 
+    storageClass: managed-nfs-storage
     storageSize: 100Gi
   ingress:
     enabled: false
@@ -49,7 +49,7 @@ gogs:
       serviceEnableCaptcha: false
       repositoryUploadMaxFileSize: 10000
     ingress:
-      enabled: true
+      enabled: false
       hosts:
       - git.cicdhub
       annotations:
@@ -59,7 +59,7 @@ gogs:
     enabled: true
     ## Customise the storage class. Leave undefined to use the default on the kubernetes cluster
     ## Use storageClass: gogs-storage if using local volumes created by volumesInit
-    #storageClass: 
+    storageClass: managed-nfs-storage
     size: 1Gi
   postgresql:
     enabled: true
@@ -70,7 +70,7 @@ gogs:
       enabled: true
       ## Customise the storage class. Leave undefined to use the default on the kubernetes cluster
       ## Use storageClass: postgresql-storage if using local volumes created by volumesInit
-      #storageClass: 
+      storageClass: managed-nfs-storage
       accessModes:
       - ReadWriteOnce
       size: 5Gi
@@ -78,11 +78,11 @@ gogs:
 jenkins:
   enabled: true
   master:
-    imageTag: 2.182
+    imageTag: 2.243
     serviceType: NodePort
     nodePort: 32732
     ingress:
-      enabled: true
+      enabled: false
       hostName: jenkins.cicdhub
     adminUser: admin
     adminPassword: admin
@@ -114,7 +114,8 @@ jenkins:
       - jsch:0.1.55.1
       - junit:1.28
       - kubernetes:1.16.0
-      - kubernetes-credentials:0.4.1
+      - kubernetes-credentials:0.7.0
+      - kubernetes-client:4.9.2-1
       - lockable-resources:2.6
       - mailer:1.29
       - matrix-project:1.14
@@ -153,22 +154,22 @@ jenkins:
     enabled: true
     ## Customise the storage class. Leave undefined to use the default on the kubernetes cluster
     ## Use storageClass: jenkins-storage if using local volumes created by volumesInit
-    #storageClass:
-    size: 1Gi
+    storageClass: managed-nfs-storage
+    size: 2Gi
 
 ## Openldap is an optional dependency for LM. An LDAP server is required when security is enabled, for user management. 
 ## Openldap is the out-of-the-box recommendation. 
 ## Full documentation for the values allowed in this section can be found at: https://github.com/helm/charts/tree/master/stable/openldap
 ## Note: remember to locate the version of the Openldap helm chart in use by viewing the requirements.yaml file of helm-foundation      
 openldap:
-  enabled: true
+  enabled: false
   replicaCount: 1
   persistence:
     enabled: true
-    size: "5Gi"
+    size: "10Gi"
     ## Customise the storage class. Leave undefined to use the default on the kubernetes cluster
     ## Use storageClass: openldap-storage if using local volumes created by volumesInit
-    #storageClass:
+    storageClass: managed-nfs-storage
   existingSecret: openldap-config
   env:
     LDAP_ORGANISATION: "lm"
@@ -187,7 +188,7 @@ openldapInit:
 
 ## Installs the nginx-ingress controller to enable access to services
 nginx-ingress:
-  enabled: true
+  enabled: false
   controller:
     service:
       type: NodePort
@@ -196,15 +197,15 @@ nginx-ingress:
         https: 32443
 
 dockerregistry:
-  enabled: true
+  enabled: false
   replicaCount: 1
   persistence:
     enabled: true
     deleteEnabled: true
-    size: 100Gi
+    size: 150Gi
     ## Customise the storage class. Leave undefined to use the default on the kubernetes cluster
     ## Use storageClass: docker-registry-storage if using local volumes created by volumesInit
-    #storageClass:
+    storageClass: managed-nfs-storage
   service:
     type: NodePort
     nodePort: 32736


### PR DESCRIPTION
Updated k8s resources with new apiversion as mentioned in below url
https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

Added selector details for deployment

Updated jenkins imageTag to use the latest supported jenkins on OCP 4.4

Updated Value.yaml to deploy only required components for cicdhub